### PR TITLE
add substitute function for repeated characters

### DIFF
--- a/lib/to_gal/extention/string.rb
+++ b/lib/to_gal/extention/string.rb
@@ -1,5 +1,5 @@
 class String
   def to_gal
-    self.tr(*ToGal::Dictionary::TR_ARGS)
+    self.gsub(/(\p{hiragana}{2})\1/, '\1②').tr(*ToGal::Dictionary::TR_ARGS)
   end
 end

--- a/spec/extention/string_spec.rb
+++ b/spec/extention/string_spec.rb
@@ -81,5 +81,19 @@ describe String do
       it { should eq 'o' }
     end
 
+    context '繰り返し文字' do
+      context 'そもそも' do
+        subject { 'そもそも'.to_gal }
+
+        it { should eq 'そも②' }
+      end
+
+      context 'いろいろ' do
+        subject { 'いろいろ'.to_gal }
+
+        it { should eq 'ぃろ②' }
+      end
+    end
+
   end
 end


### PR DESCRIPTION
`そもそも`→`そも②`のように、特定のひらがな2文字が2度繰り返された場合に
2度目の繰り返し文字列を`②`に置換するような処理を追加しました。
よろしければマージお願いします。
